### PR TITLE
Add `os` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "start": "nodemon examples/typescript/server.ts",
     "status": "node scripts/status.js"
   },
+  "os": [
+    "win32"
+  ],
   "keywords": [
     "SSPI",
     "SSO",


### PR DESCRIPTION
We're evaluating `node-expose-sspi` and our ci/cd process runs on
Linux. Other Windows-only modules in our project are handled
gracefully because the`os` field in the `package.json` file tells the
system to ignore the package.

Thanks for considering the PR!